### PR TITLE
refactor(tokens)!: remove font family from public tokens

### DIFF
--- a/data/globals/font.tokens.json
+++ b/data/globals/font.tokens.json
@@ -2,13 +2,11 @@
   "fontFamily": {
     "upright": {
       "value": "Montserrat",
-      "type": "fontFamilies",
-      "public": true
+      "type": "fontFamilies"
     },
     "monospace": {
       "value": "Roboto Mono",
-      "type": "fontFamilies",
-      "public": true
+      "type": "fontFamilies"
     }
   },
   "fontWeight": {


### PR DESCRIPTION
font family public tokens are removed to avoid confusion as typeface token are already public. font families can be customized from it.

BREAKING CHANGE: font family public tokens removed